### PR TITLE
Update encoder.py

### DIFF
--- a/src/bioc/biocxml/encoder.py
+++ b/src/bioc/biocxml/encoder.py
@@ -139,7 +139,7 @@ class BioCXMLDocumentWriter:
     Writer for the BioC XML format, one document at a time.
     """
 
-    def __init__(self, file, encoding='utf8', standalone=True):
+    def __init__(self, file, encoding='utf-8', standalone=True):
         self.encoding = encoding
         self.standalone = standalone
         self.file = file


### PR DESCRIPTION
Adding hyphan to "utf8" string in biocxml/encoder.py; created XMLs don't seem to have proper "utf-8" formatting otherwise; if hyphan is missing then "etree" throws an error when trying to open and edit an XML file created by "bioconverter".